### PR TITLE
Change the URL for api docs to point to the new location

### DIFF
--- a/_site/404.html
+++ b/_site/404.html
@@ -303,7 +303,7 @@ You can find us on <a href="http://www.cloudcoreo.com">http://www.cloudcoreo.com
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
- Site last generated: Jan 17, 2017 <br />
+ Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/backend_developer.html
+++ b/_site/backend_developer.html
@@ -324,7 +324,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> October 3, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> October 3, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/conceptdocs_advancedcomposites.html
+++ b/_site/conceptdocs_advancedcomposites.html
@@ -416,7 +416,7 @@
 
 <hr />
 
-<p>As you build new Composites, you will need to reference the <a href="http://beta.api.docs.cloudcoreo.com/docs/frames"><em>CloudCoreo API Documentation</em></a> to know what options and parameters that you can use in your Composites.</p>
+<p>As you build new Composites, you will need to reference the <a href="http://beta.api.docs.cloudcoreo.com/"><em>CloudCoreo API Documentation</em></a> to know what options and parameters that you can use in your Composites.</p>
 
 
     <div class="tags">
@@ -433,7 +433,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> November 20, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> November 20, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/conceptdocs_compositecreation.html
+++ b/_site/conceptdocs_compositecreation.html
@@ -354,7 +354,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> November 9, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> November 9, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/conceptdocs_directorystructure.html
+++ b/_site/conceptdocs_directorystructure.html
@@ -337,7 +337,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> December 27, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> December 27, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/conceptdocs_overview.html
+++ b/_site/conceptdocs_overview.html
@@ -319,7 +319,7 @@ CloudCoreo gives you a view into the running cloud Infrastructure resources that
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> January 12, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> January 12, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/conceptdocs_variables.html
+++ b/_site/conceptdocs_variables.html
@@ -351,7 +351,7 @@ You use the <code class="highlighter-rouge">type</code> field to define the type
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> January 3, 2017<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> January 3, 2017<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/feed.xml
+++ b/_site/feed.xml
@@ -5,8 +5,8 @@
         <description>CloudCoreo Documentation</description>
         <link>http://kb.cloudcoreo.com/</link>
         <atom:link href="http://kb.cloudcoreo.com/feed.xml" rel="self" type="application/rss+xml"/>
-        <pubDate>Tue, 17 Jan 2017 11:05:55 -0800</pubDate>
-        <lastBuildDate>Tue, 17 Jan 2017 11:05:55 -0800</lastBuildDate>
+        <pubDate>Mon, 23 Jan 2017 16:05:53 -0800</pubDate>
+        <lastBuildDate>Mon, 23 Jan 2017 16:05:53 -0800</lastBuildDate>
         <generator>Jekyll v3.2.1</generator>
         
         <item>

--- a/_site/index.html
+++ b/_site/index.html
@@ -319,7 +319,7 @@ CloudCoreo gives you a view into the running cloud Infrastructure resources that
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> January 12, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> January 12, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/js/mydoc_scroll.html
+++ b/_site/js/mydoc_scroll.html
@@ -540,7 +540,7 @@ $('#small-box-links').localScroll({
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> November 30, 2015<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> November 30, 2015<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_awsrolepolicy.html
+++ b/_site/mydoc_awsrolepolicy.html
@@ -326,7 +326,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> October 19, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> October 19, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_cloudtrail-service-disabled.html
+++ b/_site/mydoc_cloudtrail-service-disabled.html
@@ -634,7 +634,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> “December 22, 2016"<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> “December 22, 2016"<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_cloudtrail-trail-with-global.html
+++ b/_site/mydoc_cloudtrail-trail-with-global.html
@@ -650,7 +650,7 @@ http://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-concepts.ht
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> “December 27, 2016"<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> “December 27, 2016"<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_ec2-alert-to-kill.html
+++ b/_site/mydoc_ec2-alert-to-kill.html
@@ -635,7 +635,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> December 30, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> December 30, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_ec2-amazon-linux-not-latest.html
+++ b/_site/mydoc_ec2-amazon-linux-not-latest.html
@@ -632,7 +632,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> January 3, 2017<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> January 3, 2017<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_ec2-inventory.html
+++ b/_site/mydoc_ec2-inventory.html
@@ -629,7 +629,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> December 29, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> December 29, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_ec2-ip-address-whitelisted.html
+++ b/_site/mydoc_ec2-ip-address-whitelisted.html
@@ -631,7 +631,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_ec2-ports-range.html
+++ b/_site/mydoc_ec2-ports-range.html
@@ -634,7 +634,7 @@ http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_SecurityGroups.html</p
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_ec2-tcpportopen.html
+++ b/_site/mydoc_ec2-tcpportopen.html
@@ -635,7 +635,7 @@ Ports 1433, 1521, 27017, 3306, 3389, 5432 are checked to see if they are open to
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_ec2-unrestricted-traffic.html
+++ b/_site/mydoc_ec2-unrestricted-traffic.html
@@ -631,7 +631,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_ec2-unused-security-group.html
+++ b/_site/mydoc_ec2-unused-security-group.html
@@ -631,7 +631,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> January 3, 2017<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> January 3, 2017<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_elb-current-ssl-policy.html
+++ b/_site/mydoc_elb-current-ssl-policy.html
@@ -638,7 +638,7 @@ Elastic Load Balancing uses an Secure Socket Layer (SSL) negotiation configurati
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> December 29, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> December 29, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_elb-inventory.html
+++ b/_site/mydoc_elb-inventory.html
@@ -629,7 +629,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> December 29, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> December 29, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_elb-old-ssl-policy.html
+++ b/_site/mydoc_elb-old-ssl-policy.html
@@ -634,7 +634,7 @@ Elastic Load Balancing uses an Secure Socket Layer (SSL) negotiation configurati
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_iam-active-key-no-rotation.html
+++ b/_site/mydoc_iam-active-key-no-rotation.html
@@ -635,7 +635,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_iam-expirepasswords.html
+++ b/_site/mydoc_iam-expirepasswords.html
@@ -637,7 +637,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_iam-inactive-key-no-rotation.html
+++ b/_site/mydoc_iam-inactive-key-no-rotation.html
@@ -635,7 +635,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_iam-missing-password-policy.html
+++ b/_site/mydoc_iam-missing-password-policy.html
@@ -635,7 +635,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_iam-multiple-access-keys.html
+++ b/_site/mydoc_iam-multiple-access-keys.html
@@ -633,7 +633,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_iam-no-mfa.html
+++ b/_site/mydoc_iam-no-mfa.html
@@ -633,7 +633,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_iam-passwordreuseprevention.html
+++ b/_site/mydoc_iam-passwordreuseprevention.html
@@ -636,7 +636,7 @@ If you allow users to change their own passwords, require that they create stron
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_iam-root-active-key.html
+++ b/_site/mydoc_iam-root-active-key.html
@@ -632,7 +632,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_iam-root-active-password.html
+++ b/_site/mydoc_iam-root-active-password.html
@@ -635,7 +635,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_iam-root-no-mfa.html
+++ b/_site/mydoc_iam-root-no-mfa.html
@@ -636,7 +636,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_iam-unusediamgroup.html
+++ b/_site/mydoc_iam-unusediamgroup.html
@@ -629,7 +629,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_iam-user-attached-policies.html
+++ b/_site/mydoc_iam-user-attached-policies.html
@@ -642,7 +642,7 @@ Customer managed policies – Managed policies that you create and manage in you
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_rds-db-publicly-accessible.html
+++ b/_site/mydoc_rds-db-publicly-accessible.html
@@ -630,7 +630,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_rds-no-auto-minor-version-upgrade.html
+++ b/_site/mydoc_rds-no-auto-minor-version-upgrade.html
@@ -635,7 +635,7 @@ From the Amazon RDS standpoint, a version change would be considered major if ei
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_rds-short-backup-retention-period.html
+++ b/_site/mydoc_rds-short-backup-retention-period.html
@@ -629,7 +629,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_redshift-encrypted.html
+++ b/_site/mydoc_redshift-encrypted.html
@@ -630,7 +630,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_redshift-no-require-ssl.html
+++ b/_site/mydoc_redshift-no-require-ssl.html
@@ -628,7 +628,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_redshift-no-user-logging.html
+++ b/_site/mydoc_redshift-no-user-logging.html
@@ -633,7 +633,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_redshift-no-version-upgrade.html
+++ b/_site/mydoc_redshift-no-version-upgrade.html
@@ -628,7 +628,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_redshift-publicly-accessible.html
+++ b/_site/mydoc_redshift-publicly-accessible.html
@@ -629,7 +629,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_redshift-security-group.html
+++ b/_site/mydoc_redshift-security-group.html
@@ -653,7 +653,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_s3-allusers-read.html
+++ b/_site/mydoc_s3-allusers-read.html
@@ -640,7 +640,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_s3-allusers-write-acp.html
+++ b/_site/mydoc_s3-allusers-write-acp.html
@@ -643,7 +643,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_s3-allusers-write.html
+++ b/_site/mydoc_s3-allusers-write.html
@@ -640,7 +640,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_s3-authenticatedusers-read.html
+++ b/_site/mydoc_s3-authenticatedusers-read.html
@@ -639,7 +639,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_s3-authenticatedusers-write-acp.html
+++ b/_site/mydoc_s3-authenticatedusers-write-acp.html
@@ -639,7 +639,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_s3-authenticatedusers-write.html
+++ b/_site/mydoc_s3-authenticatedusers-write.html
@@ -640,7 +640,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_s3-logging-disabled.html
+++ b/_site/mydoc_s3-logging-disabled.html
@@ -629,7 +629,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_s3-only-ip-based-policy.html
+++ b/_site/mydoc_s3-only-ip-based-policy.html
@@ -631,7 +631,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_s3-world-open-policy-all.html
+++ b/_site/mydoc_s3-world-open-policy-all.html
@@ -638,7 +638,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_s3-world-open-policy-delete.html
+++ b/_site/mydoc_s3-world-open-policy-delete.html
@@ -638,7 +638,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_s3-world-open-policy-get.html
+++ b/_site/mydoc_s3-world-open-policy-get.html
@@ -638,7 +638,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_s3-world-open-policy-list.html
+++ b/_site/mydoc_s3-world-open-policy-list.html
@@ -638,7 +638,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/mydoc_s3-world-open-policy-put.html
+++ b/_site/mydoc_s3-world-open-policy-put.html
@@ -638,7 +638,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> September 17, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/myupdate.html
+++ b/_site/myupdate.html
@@ -290,7 +290,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
- Site last generated: Jan 17, 2017 <br />
+ Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/news.html
+++ b/_site/news.html
@@ -344,7 +344,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
- Site last generated: Jan 17, 2017 <br />
+ Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/news_archive.html
+++ b/_site/news_archive.html
@@ -662,7 +662,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
- Site last generated: Jan 17, 2017 <br />
+ Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/pages/conceptdocs/extrastuff.md
+++ b/_site/pages/conceptdocs/extrastuff.md
@@ -171,7 +171,7 @@ From Composite Creation:
 -----
 Put this back in:
 
-As you build new Composites, you will need to reference the [*CloudCoreo API Documentation*](http://beta.api.docs.cloudcoreo.com/docs/frames) to know what options and parameters that you can use in your Composites.  
+As you build new Composites, you will need to reference the [*CloudCoreo API Documentation*](http://beta.api.docs.cloudcoreo.com/) to know what options and parameters that you can use in your Composites.  
 
 
 --------

--- a/_site/passionate_devops.html
+++ b/_site/passionate_devops.html
@@ -323,7 +323,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
-<span>Page last updated:</span> October 3, 2016<br/> Site last generated: Jan 17, 2017 <br />
+<span>Page last updated:</span> October 3, 2016<br/> Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/samplepost.html
+++ b/_site/samplepost.html
@@ -292,7 +292,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
- Site last generated: Jan 17, 2017 <br />
+ Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/tag_collaboration.html
+++ b/_site/tag_collaboration.html
@@ -833,7 +833,7 @@ $('#toc').on('click', 'a', function() {
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
- Site last generated: Jan 17, 2017 <br />
+ Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/tag_content_types.html
+++ b/_site/tag_content_types.html
@@ -833,7 +833,7 @@ $('#toc').on('click', 'a', function() {
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
- Site last generated: Jan 17, 2017 <br />
+ Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/tag_formatting.html
+++ b/_site/tag_formatting.html
@@ -833,7 +833,7 @@ $('#toc').on('click', 'a', function() {
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
- Site last generated: Jan 17, 2017 <br />
+ Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/tag_getting_started.html
+++ b/_site/tag_getting_started.html
@@ -839,7 +839,7 @@ $('#toc').on('click', 'a', function() {
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
- Site last generated: Jan 17, 2017 <br />
+ Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/tag_mobile.html
+++ b/_site/tag_mobile.html
@@ -833,7 +833,7 @@ $('#toc').on('click', 'a', function() {
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
- Site last generated: Jan 17, 2017 <br />
+ Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/tag_navigation.html
+++ b/_site/tag_navigation.html
@@ -833,7 +833,7 @@ $('#toc').on('click', 'a', function() {
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
- Site last generated: Jan 17, 2017 <br />
+ Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/tag_news.html
+++ b/_site/tag_news.html
@@ -865,7 +865,7 @@ $('#toc').on('click', 'a', function() {
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
- Site last generated: Jan 17, 2017 <br />
+ Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/tag_publishing.html
+++ b/_site/tag_publishing.html
@@ -833,7 +833,7 @@ $('#toc').on('click', 'a', function() {
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
- Site last generated: Jan 17, 2017 <br />
+ Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/tag_single_sourcing.html
+++ b/_site/tag_single_sourcing.html
@@ -833,7 +833,7 @@ $('#toc').on('click', 'a', function() {
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
- Site last generated: Jan 17, 2017 <br />
+ Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/tag_special_layouts.html
+++ b/_site/tag_special_layouts.html
@@ -839,7 +839,7 @@ $('#toc').on('click', 'a', function() {
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
- Site last generated: Jan 17, 2017 <br />
+ Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/tag_troubleshooting.html
+++ b/_site/tag_troubleshooting.html
@@ -833,7 +833,7 @@ $('#toc').on('click', 'a', function() {
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
- Site last generated: Jan 17, 2017 <br />
+ Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/test-post-from-last-year.html
+++ b/_site/test-post-from-last-year.html
@@ -280,7 +280,7 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
- Site last generated: Jan 17, 2017 <br />
+ Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/titlepage/index.html
+++ b/_site/titlepage/index.html
@@ -288,7 +288,7 @@ $('#toc').on('click', 'a', function() {
   <div class="printTitleArea">
     <div class="printTitle"></div>
     <div class="printSubtitle"></div>
-    <div class="lastGeneratedDate">Last generated: January 17, 2017</div>
+    <div class="lastGeneratedDate">Last generated: January 23, 2017</div>
     <hr />
 
     <div class="printTitleImage">
@@ -318,7 +318,7 @@ $('#toc').on('click', 'a', function() {
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
- Site last generated: Jan 17, 2017 <br />
+ Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/_site/tocpage/index.html
+++ b/_site/tocpage/index.html
@@ -320,7 +320,7 @@ $('#toc').on('click', 'a', function() {
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2017 CloudCoreo. All rights reserved. <br />
- Site last generated: Jan 17, 2017 <br />
+ Site last generated: Jan 23, 2017 <br />
 <p><img src="images/company_logo.png" alt="CloudCoreo"/></p>
                 </div>
             </div>

--- a/pages/conceptdocs/advancedcomposites.md
+++ b/pages/conceptdocs/advancedcomposites.md
@@ -151,4 +151,4 @@ The *'public-subnet'* resource has been included from the `extends/services/conf
 
 -----
 
-As you build new Composites, you will need to reference the [*CloudCoreo API Documentation*](http://beta.api.docs.cloudcoreo.com/docs/frames) to know what options and parameters that you can use in your Composites.  
+As you build new Composites, you will need to reference the [*CloudCoreo API Documentation*](http://beta.api.docs.cloudcoreo.com/) to know what options and parameters that you can use in your Composites.  

--- a/pages/conceptdocs/extrastuff.md
+++ b/pages/conceptdocs/extrastuff.md
@@ -171,7 +171,7 @@ From Composite Creation:
 -----
 Put this back in:
 
-As you build new Composites, you will need to reference the [*CloudCoreo API Documentation*](http://beta.api.docs.cloudcoreo.com/docs/frames) to know what options and parameters that you can use in your Composites.  
+As you build new Composites, you will need to reference the [*CloudCoreo API Documentation*](http://beta.api.docs.cloudcoreo.com/) to know what options and parameters that you can use in your Composites.  
 
 
 --------


### PR DESCRIPTION
We moved the API docs to a new host and no longer show the items at the subroute `/docs/frames`. Update the external links to point to the domain root.